### PR TITLE
Fix for img padding

### DIFF
--- a/dist/js/jquery.magnify.js
+++ b/dist/js/jquery.magnify.js
@@ -81,8 +81,8 @@
             oContainerOffset = $container.offset();
             nContainerWidth = $container.width();
             nContainerHeight = $container.height();
-            nImageWidth = $image.width();
-            nImageHeight = $image.height();
+            nImageWidth = $image.innerWidth();
+            nImageHeight = $image.innerHeight();
             nLensWidth = $lens.width();
             nLensHeight = $lens.height();
             // Store dimensions for mobile plugin


### PR DESCRIPTION
If the *img* has any *padding*, they should be considered as well. Otherwise the magnifying lense is displayed incorrectly.
This is required, in some cases *img* tags are used with *box-sizing* set to *border-box* and padding added, which reduces the total size of which an image is displayed.

Using jQuery's *innerWidth* and *innerHeight* instead of *width* and *height* has no effect if the *img* has no padding, but it fixed the mentioned problems if *img* has *padding*.