### PR TITLE
Added settings to optionally override some automatic parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,14 +69,20 @@ $(document).ready(function() {
 
 ## Options
 
-Options can be set using data attributes or passed in an `options` JavaScript object when calling `.magnify()`. For data attributes, append the option name to "data-magnify-" (e.g., `data-magnify-src="..."`).
+Options can be set using data attributes or passed in an `options` JavaScript object when calling `.magnify()`. For data attributes, append the option name to "data-magnify-" (e.g., `data-magnify-src="..."`). Do not use camel case for data attributes.
 
-Name        | Type     | Default | Description
------------ | -------- | ------- | -----------
-`speed`     | number   | 100     | The fade-in/out animation speed in ms when the lens moves on/off the image.
-`src`       | string   | ''      | The URI of the large image that will be shown in the magnifying lens.
-`timeout`   | number   | -1      | The wait period in ms before hiding the magnifying lens on touch devices. Set to `-1` to disable.
-`afterLoad` | function |         | Callback function to execute after magnification is loaded.
+Name              | Type     | Default             | Description
+-----------       | -------- | -------             | -----------
+`speed`           | number   | 100                 | The fade-in/out animation speed in ms when the lens moves on/off the image.
+`src`             | string   | ''                  | The URI of the large image that will be shown in the magnifying lens.
+`timeout`         | number   | -1                  | The wait period in ms before hiding the magnifying lens on touch devices. Set to `-1` to disable.
+`afterLoad`       | function |                     | Callback function to execute after magnification is loaded.
+`imageheight`     | number   | $image.innerHeight()| Override the measured image height
+`imagewidth`      | number   | $image.innerWidth() | Override the measured image width
+`lensheight`      | number   | $lens.height()      | Override the actual lens height
+`lensWidth`       | number   | $lens.width()       | Override the actual lens width
+`containerHeight` | number   | $container.height() | Override the actual container height
+`containerWidth`  | number   | $container.width()  | Override the actual container width
 
 ## Methods
 

--- a/dist/js/jquery.magnify.js
+++ b/dist/js/jquery.magnify.js
@@ -38,6 +38,15 @@
               $('html').removeClass('magnifying').trigger('magnifyend'); // Reset overflow-x
             });
           };
+
+        //Initialize some optional settings
+        oSettings.imageWidth = $image.attr('data-magnify-imagewidth') || oSettings.imageWidth || null;
+        oSettings.imageHeight = $image.attr('data-magnify-imageheight') || oSettings.imageHeight || null;
+        oSettings.lensWidth = $image.attr('data-magnify-lenswidth') || oSettings.lensWidth || null;
+        oSettings.lensHeight = $image.attr('data-magnify-lensheight') || oSettings.lensHeight || null;
+        oSettings.containerWidth = $image.attr('data-magnify-containerwidth') || oSettings.containerWidth || null;
+        oSettings.containerHeight = $image.attr('data-magnify-containerheight') || oSettings.containerHeight || null;
+
         // Disable zooming if no valid zoom image source
         if (!sImgSrc) return;
 
@@ -79,12 +88,12 @@
             // important. The width and height of the object would return 0 if
             // accessed before the image is fully loaded.
             oContainerOffset = $container.offset();
-            nContainerWidth = $container.width();
-            nContainerHeight = $container.height();
-            nImageWidth = $image.innerWidth(); // Correct width with padding
-            nImageHeight = $image.innerHeight(); // Correct height with padding
-            nLensWidth = $lens.width();
-            nLensHeight = $lens.height();
+            nContainerWidth = oSettings.containerWidth || $container.width();
+            nContainerHeight = oSettings.containerHeight || $container.height();
+            nImageWidth = oSettings.imageWidth || $image.innerWidth(); // Correct width with padding
+            nImageHeight = oSettings.imageHeight || $image.innerHeight(); // Correct height with padding
+            nLensWidth = oSettings.lensWidth || $lens.width();
+            nLensHeight = oSettings.lensHeight || $lens.height();
             nMagnifiedWidth = elImage.width;
             nMagnifiedHeight = elImage.height;
             // Store dimensions for mobile plugin


### PR DESCRIPTION
This was useful for me because my image was originally styled to have a smaller size so that a scaling animation could be applied. I needed to override the height and width of the container so that I could specify the final image size so that the magnify script would function over the proper area, so I added the extra settings.