### PR TITLE
Added 'mobileCloseEvent' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Name              | Type     | Default | Description
 `magnifiedWidth`  | number   |         | Width of the image displayed inside the magnifying lens. Set this only if you want to override the large image's native width.
 `magnifiedHeight` | number   |         | Height of the image displayed inside the magnifying lens. Set this only if you want to override the large image's native height.
 `limitBounds`     | boolean  | false   | Set this to `true` to keep the edge of the image within the magnifying lens.
+`mobileCloseEvent`| string   | null    | Add a custom event name for the mobile close button. If none provided will use "touchstart".
 `afterLoad`       | function |         | Anonymous callback function to execute after magnification is loaded.
 
 Options can also be set directly in the `<img>` tag by adding the following data attributes, which will take precedence over the corresponding options set inside an object:

--- a/dist/js/jquery.magnify-mobile.js
+++ b/dist/js/jquery.magnify-mobile.js
@@ -58,8 +58,8 @@
       // NOTE: Fixed elements inside a scrolling div have issues in iOS, so we need to insert the
       // close icon at the same level as the lens.
       $magnifyMobile.hide().append('<i class="close">&times;</i>');
-      // Hook up event handlers
-      $magnifyMobile.children('.close').on('touchstart', function() {
+      // Hook up event handlers, using value of 'data-magnify-mobile-close-event' if provided
+      $magnifyMobile.children('.close').on( $("html").attr('data-magnify-mobile-close-event') || 'touchstart', function() {
         $magnifyMobile.toggle();
       });
       $magnify.children('img').on({

--- a/dist/js/jquery.magnify.js
+++ b/dist/js/jquery.magnify.js
@@ -18,6 +18,7 @@
       'magnifiedWidth': null,
       'magnifiedHeight': null,
       'limitBounds': false,
+      'mobileCloseEvent': null, // will use "touchstart" if not specified
       'afterLoad': function(){}
     }, oOptions);
 
@@ -138,6 +139,10 @@
               'width': nMagnifiedWidth,
               'height': nMagnifiedHeight
             });
+            // Store preferred mobile close event if provided
+            if(oOptions.mobileCloseEvent) {
+              $("html").attr('data-magnify-mobile-close-event', oOptions.mobileCloseEvent);
+            }
             // Clean up
             elZoomImage = null;
             // Execute callback


### PR DESCRIPTION
This is related to issue 43 (https://github.com/thdoan/magnify/issues/43).
Allows you to override the "touchstart" event on the mobile close button to avoid clicking elements beneath it when ending touch gesture.